### PR TITLE
Switch ghaction slack notif to curl

### DIFF
--- a/.github/workflows/count-incident-actions.yml
+++ b/.github/workflows/count-incident-actions.yml
@@ -56,5 +56,5 @@ jobs:
     steps:
     - name: Notify Slack channel if this job failed
       run: |
-        json="{'text':'Core team tech debt show-off :melting_face: :muscle:\nBug: ${{ needs.count_bug_issues.outputs.count }}, Incident Actions: ${{ needs.count_incident_action_issues.outputs.count }}, Tech Debt issues: ${{ needs.count_tech_debt_issues.outputs.count }}'}"
+        json="{'text':'Core team tech debt show-off :muscle: :melting_face:\nBug: ${{ needs.count_bug_issues.outputs.count }}, Incident Actions: ${{ needs.count_incident_action_issues.outputs.count }}, Tech Debt issues: ${{ needs.count_tech_debt_issues.outputs.count }}'}"
         curl -X POST -H 'Content-type: application/json' --data "$json"  ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/count-incident-actions.yml
+++ b/.github/workflows/count-incident-actions.yml
@@ -56,5 +56,5 @@ jobs:
     steps:
     - name: Notify Slack channel if this job failed
       run: |
-        json="{'text':'Core team tech debt show-off :muscle: :melting_face:\nBug: ${{ needs.count_bug_issues.outputs.count }}, Incident Actions: ${{ needs.count_incident_action_issues.outputs.count }}, Tech Debt issues: ${{ needs.count_tech_debt_issues.outputs.count }}'}"
+        json="{\"text\":\"Core team tech debt show-off :muscle: :melting_face:\nBug: ${{ needs.count_bug_issues.outputs.count }}, Incident Actions: ${{ needs.count_incident_action_issues.outputs.count }}, Tech Debt issues: ${{ needs.count_tech_debt_issues.outputs.count }}\"}"
         curl -X POST -H 'Content-type: application/json' --data "$json"  ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/count-incident-actions.yml
+++ b/.github/workflows/count-incident-actions.yml
@@ -54,10 +54,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Report to Slack
-      uses: slackapi/slack-github-action@v1.14.0
-      with:
-        slack-message: 'Core team tech debt show-off :melting_face: :muscle:\nBug: ${{ needs.count_bug_issues.outputs.count }}, Incident Actions: ${{ needs.count_incident_action_issues.outputs.count }}, Tech Debt issues: ${{ needs.count_tech_debt_issues.outputs.count }}'
-        channel-id: 'CV38DBNVA'
-      env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+    - name: Notify Slack channel if this job failed
+      run: |
+        json="{'text':'Core team tech debt show-off :melting_face: :muscle:\nBug: ${{ needs.count_bug_issues.outputs.count }}, Incident Actions: ${{ needs.count_incident_action_issues.outputs.count }}, Tech Debt issues: ${{ needs.count_tech_debt_issues.outputs.count }}'}"
+        curl -X POST -H 'Content-type: application/json' --data "$json"  ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/count-incident-actions.yml
+++ b/.github/workflows/count-incident-actions.yml
@@ -56,5 +56,5 @@ jobs:
     steps:
     - name: Notify Slack channel if this job failed
       run: |
-        json="{\"text\":\"Core team tech debt show-off :muscle: :melting_face:\nBug: ${{ needs.count_bug_issues.outputs.count }}, Incident Actions: ${{ needs.count_incident_action_issues.outputs.count }}, Tech Debt issues: ${{ needs.count_tech_debt_issues.outputs.count }}\"}"
+        json="{\"text\":\"Core team tech debt show-off :muscle: :melting_face:\nBugs: ${{ needs.count_bug_issues.outputs.count }}, Incident Actions: ${{ needs.count_incident_action_issues.outputs.count }}, Tech Debt issues: ${{ needs.count_tech_debt_issues.outputs.count }}\"}"
         curl -X POST -H 'Content-type: application/json' --data "$json"  ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
# Summary | Résumé

Reverting to our good old curl command to post to Slack.

# Test instructions | Instructions pour tester la modification

Merge and test.
