### PR TITLE
Fix Spike template not added to ZenHub

### DIFF
--- a/.github/ISSUE_TEMPLATE/spike-template.md
+++ b/.github/ISSUE_TEMPLATE/spike-template.md
@@ -1,19 +1,22 @@
-# 🚀 Spike: [Title of the Investigation]
+---
+name: Spike Template
+about: Template for creating Spike related tasks
+title: "🚀 Spike: [Title of the Investigation]"
+labels: 'SPIKE'
+assignees: ''
 
-## 📋 Quick Summary
+---
+
+# 📋 Quick Summary
 
 * **Timebox:** [e.g., 4 hours / 1 day]
 * **Primary Goal:** [e.g., Feasibility / Architecture Design / Risk Mitigation]
 
----
-
-## ❓ The Core Question
+# ❓ The Core Question
 
 > **[Insert the single, specific question this spike must answer. If this question isn't answered, the spike is incomplete.]**
 
----
-
-## 🎯 Scope & Boundaries
+# 🎯 Scope & Boundaries
 
 *To keep this spike within its timebox, we are ONLY looking at:*
 
@@ -25,9 +28,7 @@
 - [ ] [Non-essential detail 1]
 - [ ] [Implementation of the final solution]
 
----
-
-## 🛠 Expected Output / Deliverables
+# 🛠 Expected Output / Deliverables
 
 *In accordance with XP, the result should be knowledge or a prototype, not production code.*
 
@@ -35,9 +36,7 @@
 - [ ] [e.g., Throwaway prototype branch: `spike/feature-name`]
 - [ ] [e.g., New user stories/tasks created for implementation]
 
----
-
-## 📝 Findings (To be filled by the owner)
+# 📝 Findings (To be filled by the owner)
 
 *Summarize the answer to the core question here.*
 


### PR DESCRIPTION
# Summary | Résumé

* Updated the spike template so that it gets recognized by ZenHub

# Test instructions | Instructions pour tester la modification

> Sequential steps (1., 2., 3., ...) that describe how to test this change. This
> will help a developer test things out without too much detective work. Also,
> include any environmental setup steps that aren't in the normal README steps
> and/or any time-based elements that this requires.

---

> Étapes consécutives (1., 2., 3., …) qui décrivent la façon de tester la
> modification. Elles aideront les développeurs à faire des tests sans avoir à
> jouer au détective. Veuillez aussi inclure toutes les étapes de configuration
> de l’environnement qui ne font pas partie des étapes normales dans le fichier
> README et tout élément temporel requis.
